### PR TITLE
feat(HTTPError): allow extra properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,14 @@ Error by design.
 - Treat it just like `Error`. `HTTPError`'s are throwable, have full stacktrace, and even print out their status code when they're thrown.
 - Don't worry about accidentally forgetting the `new` operator, HTTPError works without it.
 - Give it just the HTTP status code you want to return, and the error message is automatically generated.
+- Assign extra properties to the error.
 
 ## Usage
+
+#### `HTTPError(status, message, properties)`
+Creates an error with the given status, message and properties. For example
+
+       new HTTPError(404, 'Not found!', { path: '/something-missing' })
 
 #### `HTTPError(status, message)`
 Creates an error message with the given status and message.

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var util = require('util');
 var http;
 
 
-var HTTPError = module.exports = function HTTPError(status, message) {
+var HTTPError = module.exports = function HTTPError(status, message, properties) {
   // Make sure we're using the 'new' keyword
   if (!(this instanceof HTTPError)) return new HTTPError(status, message);
   
@@ -27,6 +27,7 @@ var HTTPError = module.exports = function HTTPError(status, message) {
   this.name = this.constructor.name;
   this.status = status || 500;
   this.message = message || '';
+  Object.assign(this, properties);
 };
 
 util.inherits(HTTPError, Error);

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var HTTPError = module.exports = function HTTPError(status, message, properties)
   this.name = this.constructor.name;
   this.status = status || 500;
   this.message = message || '';
-  Object.assign(this, properties);
+  util._extend(this, properties);
 };
 
 util.inherits(HTTPError, Error);

--- a/test/index.js
+++ b/test/index.js
@@ -52,4 +52,11 @@ describe('HTTPError', function() {
     }
   });
 
+  it('should allow extra error properties', function() {
+    var err = new HTTPError(404, 'Not found!', { path: '/something-missing' });
+    err.should.have.property('status', 404);
+    err.should.have.property('message', 'Not found!');
+    err.should.have.property('path', '/something-missing');
+  });
+
 });


### PR DESCRIPTION
A small enhancement to assign properties to the HTTPError

    new HTTPError(404, 'Not found!', { path: '/something-missing' })
