### PR TITLE
Set statusCode as well as status

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var http;
 var HTTPError = module.exports = function HTTPError(status, message, properties) {
   // Make sure we're using the 'new' keyword
   if (!(this instanceof HTTPError)) return new HTTPError(status, message);
-  
+
   // Do the argument shuffle. If a status code is given but no message, look up
   // the message from the Node.js HTTP module
   if (typeof status !== 'number') {
@@ -22,10 +22,10 @@ var HTTPError = module.exports = function HTTPError(status, message, properties)
 
   Error.call(this); //super constructor
   Error.captureStackTrace(this, this.constructor);
-  
+
   // Setup error details
   this.name = this.constructor.name;
-  this.status = status || 500;
+  this.status = this.statusCode = status || 500;
   this.message = message || '';
   util._extend(this, properties);
 };
@@ -36,5 +36,3 @@ util.inherits(HTTPError, Error);
 HTTPError.prototype.toString = function() {
   return this.name + ': ' + this.status + ' ' + this.message;
 };
-
-


### PR DESCRIPTION
First, thanks for being the only HTTP error library I could find that allows `message` and `status`, defaults to the HTTP error message if no message is given, and isn't hundreds of lines of code for no reason.

Now, this PR: all of the error tracking and unit testing in my app currently checks for `.statusCode` instead of `.status`.

I'd hate to make it inconsistent or have to check for both `statusCode` and `status` -- could this library just set both?